### PR TITLE
Prevent the deletion of domains with sub-domains

### DIFF
--- a/infoblox/resource_infoblox_zone_auth_test.go
+++ b/infoblox/resource_infoblox_zone_auth_test.go
@@ -2,6 +2,7 @@ package infoblox
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -10,27 +11,81 @@ import (
 )
 
 func TestAccResourceZoneAuth(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckZoneAuthDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccresourceZoneAuthCreate,
+				Config: testStep1CreateSingleZone,
 				Check: resource.ComposeTestCheckFunc(
-					testAccZoneAuthExists(t, "infoblox_zone_auth.zone_auth", "aaa.com", "default", "test"),
+					testAccZoneAuthExists(t, "infoblox_zone_auth.acctest", "aaa.com", "default", "test"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccresourceZoneAuthUpdate,
+				Config: testStep2CreateASubDomain,
 				Check: resource.ComposeTestCheckFunc(
-					testAccZoneAuthExists(t, "infoblox_zone_auth.zone_auth", "aaa.com", "default", "test"),
+					testAccZoneAuthExists(t, "infoblox_zone_auth.acctest", "aaa.com", "default", "test"),
+					testAccZoneAuthExists(t, "infoblox_zone_auth.sub_acctest", "sub.aaa.com", "default", "test"),
+				),
+			},
+			// We expect this step to fail as you can't delete a domain with sub-domains
+			resource.TestStep{
+				Config:      testStep3DeleteParentZone,
+				ExpectError: regexp.MustCompile("Cannot delete an AuthZone that has a sub-domain"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccZoneAuthExists(t, "infoblox_zone_auth.acctest", "aaa.com", "default", "test"),
+					testAccZoneAuthExists(t, "infoblox_zone_auth.sub_acctest", "sub.aaa.com", "default", "test"),
+				),
+			},
+			// This final step is to remove the sub-domain so that the state can be cleaned properly
+			resource.TestStep{
+				Config: testStep4DeleteSubDomain,
+				Check: resource.ComposeTestCheckFunc(
+					testAccZoneAuthExists(t, "infoblox_zone_auth.acctest", "aaa.com", "default", "test"),
 				),
 			},
 		},
 	})
 }
+
+var testStep1CreateSingleZone = fmt.Sprintf(`
+	resource "infoblox_zone_auth" "acctest" {
+		fqdn = "acctest.com"
+		dns_view="default"
+		tenant_id="test"
+	}
+`)
+
+var testStep2CreateASubDomain = fmt.Sprintf(`
+	resource "infoblox_zone_auth" "acctest" {
+		fqdn = "acctest.com"
+		dns_view="default"
+		tenant_id="test"
+	}
+
+	resource "infoblox_zone_auth" "sub_acctest" {
+		fqdn = "sub.acctest.com"
+		dns_view="default"
+		tenant_id="test"
+	}
+`)
+
+var testStep3DeleteParentZone = fmt.Sprintf(`
+	resource "infoblox_zone_auth" "sub_acctest" {
+		fqdn = "sub.acctest.com"
+		dns_view="default"
+		tenant_id="test"
+	}
+`)
+
+var testStep4DeleteSubDomain = fmt.Sprintf(`
+	resource "infoblox_zone_auth" "acctest" {
+		fqdn = "acctest.com"
+		dns_view="default"
+		tenant_id="test"
+	}
+`)
 
 func testAccCheckZoneAuthDestroy(s *terraform.State) error {
 	meta := testAccProvider.Meta()
@@ -45,10 +100,10 @@ func testAccCheckZoneAuthDestroy(s *terraform.State) error {
 		if err != nil {
 			return fmt.Errorf("Error:%s - record not found", err)
 		}
-
 	}
 	return nil
 }
+
 func testAccZoneAuthExists(t *testing.T, n string, fqdn string, dns_view string, tenant_id string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -71,16 +126,20 @@ func testAccZoneAuthExists(t *testing.T, n string, fqdn string, dns_view string,
 	}
 }
 
-var testAccresourceZoneAuthCreate = fmt.Sprintf(`
-resource "infoblox_zone_auth" "zone_auth"{
-	fqdn = "acctest.com"
-	dns_view="default"
-	tenant_id="test"
-	}`)
+func TestHasSubdomain(t *testing.T) {
+	main := ibclient.ZoneAuth{Fqdn: "aaa.com"}
+	subdomain := ibclient.ZoneAuth{Fqdn: "test.aaa.com"}
+	other := ibclient.ZoneAuth{Fqdn: "foo.com"}
 
-var testAccresourceZoneAuthUpdate = fmt.Sprintf(`
-resource "infoblox_zone_auth" "zone_auth"{
-	fqdn = "acctest.com"
-	dns_view="default"
-	tenant_id="test"
-	}`)
+	list := []ibclient.ZoneAuth{main, subdomain, other}
+
+	if hasSubdomain(main, list) == false {
+		fmt.Printf("'%s' has not been identified as having a subdomain", main.Fqdn)
+		t.Fail()
+	}
+
+	if hasSubdomain(other, list) == true {
+		fmt.Printf("'%s' has been identified incorrectly as having a subdomain", other.Fqdn)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This stops the accidental deletion of sub-domains within Infoblox when
the parent domain is deleted.  In order for a parent domain to be
deleted now, the sub-domains will need to be removed first.

This can be protected against with the `depends_on` directive within the
users terraform code (sub-domains referencing parent domains) but this
is easily forgotten.